### PR TITLE
Add Lair Actions and Region Effects support

### DIFF
--- a/dnd/css/statblock-style.css
+++ b/dnd/css/statblock-style.css
@@ -189,6 +189,19 @@
     padding-top: 10px;
 }
 
+.lairregion {
+    padding-top: 0;
+}
+
+.lairregion p {
+    font-style: normal;
+}
+
+#traits-list-right> :first-child.property-block.lairregion {
+    /* for a rare edge case where a lair action is the first item in the second column */
+    padding-top: 10px;
+}
+
 .actions h3 {
     border-bottom: 2px solid #7A200D;
     color: #7A200D;

--- a/dnd/css/statblock-style.css
+++ b/dnd/css/statblock-style.css
@@ -189,15 +189,15 @@
     padding-top: 10px;
 }
 
-.lairregion {
+.lairregional {
     padding-top: 0;
 }
 
-.lairregion p {
+.lairregional p {
     font-style: normal;
 }
 
-#traits-list-right> :first-child.property-block.lairregion {
+#traits-list-right> :first-child.property-block.lairregional {
     /* for a rare edge case where a lair action is the first item in the second column */
     padding-top: 10px;
 }

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -532,6 +532,8 @@
                     <br>
                     <b>Lair Actions Description:</b>
                     <div><label for="lair-descsection-input" style="width: 100%"><textarea id="lair-descsection-input" rows="4"></textarea></label></div>
+                    <b>Lair Actions End Note Description:</b>
+                    <div><label for="lair-end-descsection-input" style="width: 100%"><textarea id="lair-end-descsection-input" rows="4"></textarea></label></div>
                     <div><button type="button" onclick="InputFunctions.LairDescriptionDefaultInput()">Reset to Default</button></div>
                 </div>
                 <div id="regional-actions-form">

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -520,7 +520,7 @@
                 <div id="legendary-actions-form">
                     <br>
                     <label for="has-lair-input"><b>Lair:</b> <input type="checkbox" id="has-lair-input" onclick="FormFunctions.ShowHideLair()"></label>
-                    <label for="has-region-input"><b>Region:</b> <input type="checkbox" id="has-region-input" onclick="FormFunctions.ShowHideRegion()"></label>
+                    <label for="has-regional-input"><b>Regional:</b> <input type="checkbox" id="has-regional-input" onclick="FormFunctions.ShowHideRegional()"></label>
                     <br><br>
                     <b>Legendary Actions Description:</b>
                     <div><label for="legendaries-descsection-input" style="width: 100%"><textarea
@@ -534,11 +534,11 @@
                     <div><label for="lair-descsection-input" style="width: 100%"><textarea id="lair-descsection-input" rows="4"></textarea></label></div>
                     <div><button type="button" onclick="InputFunctions.LairDescriptionDefaultInput()">Reset to Default</button></div>
                 </div>
-                <div id="region-actions-form">
+                <div id="regional-actions-form">
                     <br>
-                    <b>Region Effects Description:</b>
-                    <div><label for="region-descsection-input" style="width: 100%"><textarea id="region-descsection-input" rows="4"></textarea></label></div>
-                    <div><button type="button" onclick="InputFunctions.RegionDescriptionDefaultInput()">Reset to Default</button></div>
+                    <b>Regional Effects Description:</b>
+                    <div><label for="regional-descsection-input" style="width: 100%"><textarea id="regional-descsection-input" rows="4"></textarea></label></div>
+                    <div><button type="button" onclick="InputFunctions.RegionalDescriptionDefaultInput()">Reset to Default</button></div>
                 </div>
                 <br>
                 <b>Abilities:</b>
@@ -555,7 +555,7 @@
                     <button type="button" id="add-legendary-button"
                         onclick="InputFunctions.AddAbilityInput('legendaries')">Add Legendary Action</button>
                     <button type="button" id="add-lair-button" onclick="InputFunctions.AddAbilityInput('lairs')">Add Lair Action</button>
-                    <button type="button" id="add-region-button" onclick="InputFunctions.AddAbilityInput('regions')">Add Region Effect</button>
+                    <button type="button" id="add-regional-button" onclick="InputFunctions.AddAbilityInput('regionals')">Add Regional Effect</button>
                 </div>
                 <div>
                     <select id="common-ability-input"></select>
@@ -597,8 +597,8 @@
                     <div id="lairs-input-section"><b>Lair Actions:</b><br>
                         <ul id="lairs-input-list" class="statblock-list"></ul>
                     </div>
-                    <div id="regions-input-section"><b>Region Effects:</b><br>
-                        <ul id="regions-input-list" class="statblock-list"></ul>
+                    <div id="regionals-input-section"><b>Regional Effects:</b><br>
+                        <ul id="regionals-input-list" class="statblock-list"></ul>
                     </div>
                 </div>
                 <br>

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -538,6 +538,8 @@
                     <br>
                     <b>Regional Effects Description:</b>
                     <div><label for="regional-descsection-input" style="width: 100%"><textarea id="regional-descsection-input" rows="4"></textarea></label></div>
+                    <b>Regional Effects End Note Description:</b>
+                    <div><label for="regional-end-descsection-input" style="width: 100%"><textarea id="regional-end-descsection-input" rows="4"></textarea></label></div>
                     <div><button type="button" onclick="InputFunctions.RegionalDescriptionDefaultInput()">Reset to Default</button></div>
                 </div>
                 <br>

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -519,11 +519,26 @@
                 </div>
                 <div id="legendary-actions-form">
                     <br>
+                    <label for="has-lair-input"><b>Lair:</b> <input type="checkbox" id="has-lair-input" onclick="FormFunctions.ShowHideLair()"></label>
+                    <label for="has-region-input"><b>Region:</b> <input type="checkbox" id="has-region-input" onclick="FormFunctions.ShowHideRegion()"></label>
+                    <br><br>
                     <b>Legendary Actions Description:</b>
                     <div><label for="legendaries-descsection-input" style="width: 100%"><textarea
                                 id="legendaries-descsection-input" rows="4"></textarea></label></div>
                     <div><button type="button" onclick="InputFunctions.LegendaryDescriptionDefaultInput()">Reset to
                             Default</button></div>
+                </div>
+                <div id="lair-actions-form">
+                    <br>
+                    <b>Lair Actions Description:</b>
+                    <div><label for="lair-descsection-input" style="width: 100%"><textarea id="lair-descsection-input" rows="4"></textarea></label></div>
+                    <div><button type="button" onclick="InputFunctions.LairDescriptionDefaultInput()">Reset to Default</button></div>
+                </div>
+                <div id="region-actions-form">
+                    <br>
+                    <b>Region Effects Description:</b>
+                    <div><label for="region-descsection-input" style="width: 100%"><textarea id="region-descsection-input" rows="4"></textarea></label></div>
+                    <div><button type="button" onclick="InputFunctions.RegionDescriptionDefaultInput()">Reset to Default</button></div>
                 </div>
                 <br>
                 <b>Abilities:</b>
@@ -539,6 +554,8 @@
                         onclick="InputFunctions.AddAbilityInput('reactions')">Add Reaction</button>
                     <button type="button" id="add-legendary-button"
                         onclick="InputFunctions.AddAbilityInput('legendaries')">Add Legendary Action</button>
+                    <button type="button" id="add-lair-button" onclick="InputFunctions.AddAbilityInput('lairs')">Add Lair Action</button>
+                    <button type="button" id="add-region-button" onclick="InputFunctions.AddAbilityInput('regions')">Add Region Effect</button>
                 </div>
                 <div>
                     <select id="common-ability-input"></select>
@@ -576,6 +593,12 @@
                     </div>
                     <div id="legendaries-input-section"><b>Legendary Actions:</b><br>
                         <ul id="legendaries-input-list" class="statblock-list"></ul>
+                    </div>
+                    <div id="lairs-input-section"><b>Lair Actions:</b><br>
+                        <ul id="lairs-input-list" class="statblock-list"></ul>
+                    </div>
+                    <div id="regions-input-section"><b>Region Effects:</b><br>
+                        <ul id="regions-input-list" class="statblock-list"></ul>
                     </div>
                 </div>
                 <br>

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -495,8 +495,8 @@
                     <br>
                     <div id="prof-bonus"></div>
                     <div id="custom-cr">
-                        <label for="custom-cr-input">CR Text: <input id="custom-cr-input" type="text"
-                                value="1 (200 XP)" placeholder="Leave blank to hide" style="width: 16rem;"></label>
+                        <label for="custom-cr-input">CR Text: <input id="custom-cr-input" type="text" value="1 (200 XP)"
+                                placeholder="Leave blank to hide" style="width: 16rem;"></label>
                         <br>
                         <label for="custom-prof-input">Proficiency Bonus: <input type="number" id="custom-prof-input"
                                 min="0" max="99" value="2"></label>
@@ -519,8 +519,10 @@
                 </div>
                 <div id="legendary-actions-form">
                     <br>
-                    <label for="has-lair-input"><b>Lair:</b> <input type="checkbox" id="has-lair-input" onclick="FormFunctions.ShowHideLair()"></label>
-                    <label for="has-regional-input"><b>Regional:</b> <input type="checkbox" id="has-regional-input" onclick="FormFunctions.ShowHideRegional()"></label>
+                    <label for="has-lair-input"><b>Lair:</b> <input type="checkbox" id="has-lair-input"
+                            onclick="FormFunctions.ShowHideLair()"></label>
+                    <label for="has-regional-input"><b>Regional:</b> <input type="checkbox" id="has-regional-input"
+                            onclick="FormFunctions.ShowHideRegional()"></label>
                     <br><br>
                     <b>Legendary Actions Description:</b>
                     <div><label for="legendaries-descsection-input" style="width: 100%"><textarea
@@ -531,18 +533,24 @@
                 <div id="lair-actions-form">
                     <br>
                     <b>Lair Actions Description:</b>
-                    <div><label for="lair-descsection-input" style="width: 100%"><textarea id="lair-descsection-input" rows="4"></textarea></label></div>
+                    <div><label for="lair-descsection-input" style="width: 100%"><textarea id="lair-descsection-input"
+                                rows="4"></textarea></label></div>
                     <b>Lair Actions End Note Description:</b>
-                    <div><label for="lair-end-descsection-input" style="width: 100%"><textarea id="lair-end-descsection-input" rows="4"></textarea></label></div>
-                    <div><button type="button" onclick="InputFunctions.LairDescriptionDefaultInput()">Reset to Default</button></div>
+                    <div><label for="lair-end-descsection-input" style="width: 100%"><textarea
+                                id="lair-end-descsection-input" rows="4"></textarea></label></div>
+                    <div><button type="button" onclick="InputFunctions.LairDescriptionDefaultInput()">Reset to
+                            Default</button></div>
                 </div>
                 <div id="regional-actions-form">
                     <br>
                     <b>Regional Effects Description:</b>
-                    <div><label for="regional-descsection-input" style="width: 100%"><textarea id="regional-descsection-input" rows="4"></textarea></label></div>
+                    <div><label for="regional-descsection-input" style="width: 100%"><textarea
+                                id="regional-descsection-input" rows="4"></textarea></label></div>
                     <b>Regional Effects End Note Description:</b>
-                    <div><label for="regional-end-descsection-input" style="width: 100%"><textarea id="regional-end-descsection-input" rows="4"></textarea></label></div>
-                    <div><button type="button" onclick="InputFunctions.RegionalDescriptionDefaultInput()">Reset to Default</button></div>
+                    <div><label for="regional-end-descsection-input" style="width: 100%"><textarea
+                                id="regional-end-descsection-input" rows="4"></textarea></label></div>
+                    <div><button type="button" onclick="InputFunctions.RegionalDescriptionDefaultInput()">Reset to
+                            Default</button></div>
                 </div>
                 <br>
                 <b>Abilities:</b>
@@ -558,8 +566,10 @@
                         onclick="InputFunctions.AddAbilityInput('reactions')">Add Reaction</button>
                     <button type="button" id="add-legendary-button"
                         onclick="InputFunctions.AddAbilityInput('legendaries')">Add Legendary Action</button>
-                    <button type="button" id="add-lair-button" onclick="InputFunctions.AddAbilityInput('lairs')">Add Lair Action</button>
-                    <button type="button" id="add-regional-button" onclick="InputFunctions.AddAbilityInput('regionals')">Add Regional Effect</button>
+                    <button type="button" id="add-lair-button" onclick="InputFunctions.AddAbilityInput('lairs')">Add
+                        Lair Action</button>
+                    <button type="button" id="add-regional-button"
+                        onclick="InputFunctions.AddAbilityInput('regionals')">Add Regional Effect</button>
                 </div>
                 <div>
                     <select id="common-ability-input"></select>

--- a/dnd/js/JSON/statblockdata.json
+++ b/dnd/js/JSON/statblockdata.json
@@ -414,6 +414,10 @@
 		"reactions": "",
 		"legendary_actions": "",
 		"legendary_desc": "",
+		"lair_actions": "",
+		"lair_desc": "",
+		"region_actions": "",
+		"region_desc": "",
 		"special_abilities": "",
 		"document_slug": "systems-reference-document"
 	},

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -40,15 +40,15 @@ var mon = {
     legendariesDescription: "",
     isLair: false,
     lairDescription: "",
-    isRegion: false,
-    regionDescription: "",
+    isRegional: false,
+    regionalDescription: "",
     properties: [],
     abilities: [],
     actions: [],
     reactions: [],
     legendaries: [],
     lairs: [],
-    regions: [],
+    regionals: [],
     sthrows: [],
     skills: [],
     damagetypes: [],
@@ -140,8 +140,8 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.isLair)
         separationMax += (mon.lairs.length == 0 ? 1 : mon.lairs.length);
     
-    if (mon.isRegion)
-        separationMax += (mon.regions.length == 0 ? 1 : mon.regions.length);
+    if (mon.isRegional)
+        separationMax += (mon.regionals.length == 0 ? 1 : mon.regionals.length);
 
     if (mon.separationPoint == undefined)
         mon.separationPoint = Math.floor(separationMax / 2);
@@ -208,8 +208,8 @@ function UpdateStatblock(moveSeparationPoint) {
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
     if (mon.isLair && mon.isLegendary)
         AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
-    if (mon.isRegion && mon.isLegendary)    
-        AddToTraitList(traitsHTML, mon.regions, mon.regionDescription == "" ? "<h3>Region Effects</h3>" : ["<h3>Region Effects</h3><div class='property-block'>", mon.regionDescription, "</div></br>"], false, true);
+    if (mon.isRegional && mon.isLegendary)    
+        AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", mon.regionalDescription, "</div></br>"], false, true);
     
     // Add traits, taking into account the width of the block (one column or two columns)
     let leftTraitsArr = [],
@@ -234,7 +234,7 @@ function UpdateStatblock(moveSeparationPoint) {
 }
 
 // Function used by UpdateStatblock for abilities
-function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false, isLairRegion = false) {
+function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false, isLairRegional = false) {
 
     // Add specific elements to the beginning of the array, usually a header
     if (addElements != undefined) {
@@ -245,12 +245,12 @@ function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false,
             traitsHTML.push("*" + addElements);
     }
 
-    // There's a small difference in formatting for legendary actions and lair/region actions
+    // There's a small difference in formatting for legendary actions and lair/regional actions
     for (let index = 0; index < traitsArr.length; index++){
         if(isLegendary){
             traitsHTML.push(StringFunctions.MakeTraitHTMLLegendary(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
-	    } else if (isLairRegion) {
-            traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegion(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+	    } else if (isLairRegional) {
+            traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegional(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
 	    } else {
             traitsHTML.push(StringFunctions.MakeTraitHTML(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
 	    }
@@ -402,9 +402,9 @@ function TryMarkdown() {
         markdown.push("<br>> ### Lair Actions<br>> ", mon.lairDescription);
         if (mon.lairs.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.lairs, false, true));
     }
-    if (mon.isRegion && mon.isLegendary) {
-        markdown.push("<br>><br>> ### Region Effects<br>> ", mon.regionDescription);
-        if (mon.regions.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.regions, false, true));
+    if (mon.isRegional && mon.isLegendary) {
+        markdown.push("<br>><br>> ### Regional Effects<br>> ", mon.regionalDescription);
+        if (mon.regionals.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.regionals, false, true));
     }
 
     markdown.push("</code></body></html>")
@@ -412,7 +412,7 @@ function TryMarkdown() {
     markdownWindow.document.write(markdown.join(""));
 }
 
-function GetTraitMarkdown(traitArr, legendary = false, lairOrRegion = false) {
+function GetTraitMarkdown(traitArr, legendary = false, lairOrRegional = false) {
     let markdown = [];
     for (let index = 0; index < traitArr.length; index++) {
         let desc = ReplaceTraitTags(traitArr[index].desc)
@@ -420,9 +420,9 @@ function GetTraitMarkdown(traitArr, legendary = false, lairOrRegion = false) {
             .replace(/(\r\n|\r|\n)>/g, '\&lt;br&gt;<br>>')
             .replace(/(\r\n|\r|\n)/g, '\&lt;br&gt;<br>> &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;');
         markdown.push("> " +
-            (legendary ? "**" : (lairOrRegion ? "* " : "***")) +
-            (lairOrRegion ? "" : traitArr[index].name) +
-            (legendary ? ".** " : lairOrRegion ? "" : (".*** ")) +
+            (legendary ? "**" : (lairOrRegional ? "* " : "***")) +
+            (lairOrRegional ? "" : traitArr[index].name) +
+            (legendary ? ".** " : lairOrRegional ? "" : (".*** ")) +
             desc);
     }
     return markdown.join("<br>><br>");
@@ -507,7 +507,7 @@ var FormFunctions = {
         this.MakeDisplayList("reactions", false, true);
         this.MakeDisplayList("legendaries", false, true);
         this.MakeDisplayList("lairs", false, true);
-        this.MakeDisplayList("regions", false, true);
+        this.MakeDisplayList("regionals", false, true);
 
         // Is Legendary?	
         $("#is-legendary-input").prop("checked", mon.isLegendary);
@@ -517,9 +517,9 @@ var FormFunctions = {
         $("#has-lair-input").prop("checked", mon.isLair);
         this.ShowHideLair();
 
-        // Is Region?	
-        $("#has-region-input").prop("checked", mon.isRegion);
-        this.ShowHideRegion();
+        // Is Regional?	
+        $("#has-regional-input").prop("checked", mon.isRegional);
+        this.ShowHideRegional();
 
         // Challenge Rating
         $("#cr-input").val(mon.cr);
@@ -588,11 +588,11 @@ var FormFunctions = {
             $("#add-legendary-button, #legendary-actions-form").show();
             if($("#has-lair-input:checked").val())
                 $("#add-lair-button, #lair-actions-form").show();
-            if($("#has-region-input:checked").val())
-                $("#add-region-button, #region-actions-form").show();           
+            if($("#has-regional-input:checked").val())
+                $("#add-regional-button, #regional-actions-form").show();           
     } else {
             $("#add-legendary-button, #legendary-actions-form").hide();
-            $("#add-lair-button, #add-region-button, #lair-actions-form, #region-actions-form").hide();
+            $("#add-lair-button, #add-regional-button, #lair-actions-form, #regional-actions-form").hide();
     }
     },
 
@@ -602,10 +602,10 @@ var FormFunctions = {
             $("#add-lair-button, #lair-actions-form").hide();
     },
 
-    ShowHideRegion: function() {
-        $("#has-region-input:checked").val() ?
-            $("#add-region-button, #region-actions-form").show() :
-            $("#add-region-button, #region-actions-form").hide();
+    ShowHideRegional: function() {
+        $("#has-regional-input:checked").val() ?
+            $("#add-regional-button, #regional-actions-form").show() :
+            $("#add-regional-button, #regional-actions-form").hide();
     },
 
     ShowHideFormatHelper: function () {
@@ -648,9 +648,9 @@ var FormFunctions = {
         $("#lair-descsection-input").val(mon.lairDescription);
     },
 
-    // For setting the region effect description
-    SetRegionDescriptionForm: function() {
-        $("#region-descsection-input").val(mon.regionDescription);
+    // For setting the regional effect description
+    SetRegionalDescriptionForm: function() {
+        $("#regional-descsection-input").val(mon.regionalDescription);
     },
 
     SetCommonAbilitiesDropdown: function () {
@@ -849,10 +849,10 @@ var InputFunctions = {
         FormFunctions.SetLairDescriptionForm();
     },
 
-    // Reset region description to default
-    RegionDescriptionDefaultInput: function() {
-        GetVariablesFunctions.RegionDescriptionDefault();
-        FormFunctions.SetRegionDescriptionForm();
+    // Reset regional description to default
+    RegionalDescriptionDefaultInput: function() {
+        GetVariablesFunctions.RegionalDescriptionDefault();
+        FormFunctions.SetRegionalDescriptionForm();
     },
 
     AddCommonAbilityInput: function () {
@@ -937,10 +937,10 @@ var GetVariablesFunctions = {
             mon.lairDescription = $("#lair-descsection-input").val().trim();
         }
 
-        // Region
-        mon.isRegion = $("#has-region-input").prop("checked");
-        if (mon.isRegion){
-            mon.regionDescription = $("#region-descsection-input").val().trim();
+        // Regional
+        mon.isRegional = $("#has-regional-input").prop("checked");
+        if (mon.isRegional){
+            mon.regionalDescription = $("#regional-descsection-input").val().trim();
         }
 
         // One or two columns ?
@@ -1176,13 +1176,13 @@ var GetVariablesFunctions = {
             mon.lairDescription = preset.lair_desc;
         FormFunctions.SetLairDescriptionForm();
 
-        // Region Effects?
-        mon.isRegion = Array.isArray(preset.region_actions);
-        if (preset.region_desc == null || preset.region_desc.length == 0)
-            this.RegionDescriptionDefault();
+        // Regional Effects?
+        mon.isRegional = Array.isArray(preset.regional_actions);
+        if (preset.regional_desc == null || preset.regional_desc.length == 0)
+            this.RegionalDescriptionDefault();
         else
-            mon.regionDescription = preset.region_desc;
-        FormFunctions.SetRegionDescriptionForm();
+            mon.regionalDescription = preset.regional_desc;
+        FormFunctions.SetRegionalDescriptionForm();
 
         // Abilities
         mon.abilities = [];
@@ -1190,13 +1190,13 @@ var GetVariablesFunctions = {
         mon.reactions = [];
         mon.legendaries = [];
         mon.lairs = [];
-        mon.regions = [];
+        mon.regionals = [];
         let abilitiesPresetArr = preset.special_abilities,
             actionsPresetArr = preset.actions,
             reactionsPresetArr = preset.reactions,
             legendariesPresetArr = preset.legendary_actions,
             lairsPresetArr = preset.lair_actions,
-            regionsPresetArr = preset.region_actions;
+            regionalsPresetArr = preset.regional_actions;
 
         let self = this,
             AbilityPresetLoop = function (arr, name) {
@@ -1213,8 +1213,8 @@ var GetVariablesFunctions = {
             AbilityPresetLoop(legendariesPresetArr, "legendaries");
         if (mon.isLair)
             AbilityPresetLoop(lairsPresetArr, "lairs");
-        if (mon.isRegion)
-            AbilityPresetLoop(regionsPresetArr, "regions");
+        if (mon.isRegional)
+            AbilityPresetLoop(regionalsPresetArr, "regionals");
 
         mon.separationPoint = undefined; // This will make the separation point be automatically calculated in UpdateStatblock
     },
@@ -1405,10 +1405,10 @@ var GetVariablesFunctions = {
         mon.lairDescription = "When fighting inside it's lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " takes a lair action to cause one of the following effects:";
     },
 
-    // Return the default region description
-    RegionDescriptionDefault: function() {
+    // Return the default regional description
+    RegionalDescriptionDefault: function() {
         let monsterName = name.toLowerCase();
-        mon.regionDescription = "The region containing the " + mon.name.toLowerCase() + "'s lair is warped by the creature's presence, which creates one or more of the following effects:";
+        mon.regionalDescription = "The region containing the " + mon.name.toLowerCase() + "'s lair is warped by the creature's presence, which creates one or more of the following effects:";
     }
 }
 
@@ -1640,8 +1640,8 @@ var StringFunctions = {
         return "<div class=\"property-block reverse-indent legendary\"><div><h4>" + name + ".</h4><p> " + this.FormatString(description, true) + "</p></div></div> <!-- property block -->";
     },
 
-    MakeTraitHTMLLairRegion: function(name, description) {
-        return "<div class=\"property-block lairregion\"><div><ul><li>" + this.FormatString(description, true) + "</li></ul></div></div> <!-- property block -->";
+    MakeTraitHTMLLairRegional: function(name, description) {
+        return "<div class=\"property-block lairregional\"><div><ul><li>" + this.FormatString(description, true) + "</li></ul></div></div> <!-- property block -->";
     },
 
     // General string operations
@@ -1782,7 +1782,7 @@ $(function () {
 function Populate() {
     FormFunctions.SetLegendaryDescriptionForm();
     FormFunctions.SetLairDescriptionForm();
-    FormFunctions.SetRegionDescriptionForm();
+    FormFunctions.SetRegionalDescriptionForm();
     FormFunctions.SetCommonAbilitiesDropdown();
 
     // Populate the stat block

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -207,14 +207,14 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.actions.length > 0) AddToTraitList(traitsHTML, mon.actions, "<h3>Actions</h3>");
     if (mon.reactions.length > 0) AddToTraitList(traitsHTML, mon.reactions, "<h3>Reactions</h3>");
     if (mon.isLegendary)
-        AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
+        AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", ReplaceTags(mon.legendariesDescription), "</div></br>"], true);
     if (mon.isLair && mon.isLegendary) {
-        AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
-        traitsHTML.push("*" + mon.lairDescriptionEnd);
+        AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", ReplaceTags(mon.lairDescription), "</div></br>"], false, true);
+        traitsHTML.push("*" + ReplaceTags(mon.lairDescriptionEnd));
     }
     if (mon.isRegional && mon.isLegendary) {
-        AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", mon.regionalDescription, "</div></br>"], false, true);
-        traitsHTML.push("*" + mon.regionalDescriptionEnd);
+        AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", ReplaceTags(mon.regionalDescription), "</div></br>"], false, true);
+        traitsHTML.push("*" + ReplaceTags(mon.regionalDescriptionEnd));
     }
 
     // Add traits, taking into account the width of the block (one column or two columns)
@@ -254,16 +254,16 @@ function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false,
     // There's a small difference in formatting for legendary actions and lair/regional actions
     for (let index = 0; index < traitsArr.length; index++) {
         if (isLegendary) {
-            traitsHTML.push(StringFunctions.MakeTraitHTMLLegendary(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+            traitsHTML.push(StringFunctions.MakeTraitHTMLLegendary(traitsArr[index].name, ReplaceTags(traitsArr[index].desc)));
         } else if (isLairRegional) {
-            traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegional(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+            traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegional(traitsArr[index].name, ReplaceTags(traitsArr[index].desc)));
         } else {
-            traitsHTML.push(StringFunctions.MakeTraitHTML(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+            traitsHTML.push(StringFunctions.MakeTraitHTML(traitsArr[index].name, ReplaceTags(traitsArr[index].desc)));
         }
     }
 }
 
-function ReplaceTraitTags(desc) {
+function ReplaceTags(desc) {
     const bracketExp = /\[(.*?)\]/g,
         damageExp = /\d*d\d+/,
         bonusExp = /^[+-] ?(\d+)$/;
@@ -401,18 +401,18 @@ function TryMarkdown() {
     if (mon.actions.length > 0) markdown.push("<br>> ### Actions<br>", GetTraitMarkdown(mon.actions, false));
     if (mon.reactions.length > 0) markdown.push("<br>> ### Reactions<br>", GetTraitMarkdown(mon.reactions, false));
     if (mon.isLegendary) {
-        markdown.push("<br>> ### Legendary Actions<br>> ", mon.legendariesDescription);
+        markdown.push("<br>> ### Legendary Actions<br>> ", ReplaceTags(mon.legendariesDescription));
         if (mon.legendaries.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.legendaries, true));
     }
     if (mon.isLair && mon.isLegendary) {
-        markdown.push("<br>> ### Lair Actions<br>> ", mon.lairDescription);
+        markdown.push("<br>> ### Lair Actions<br>> ", ReplaceTags(mon.lairDescription));
         if (mon.lairs.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.lairs, false, true));
-        markdown.push("<br>><br>>", mon.lairDescriptionEnd);
+        markdown.push("<br>><br>>", ReplaceTags(mon.lairDescriptionEnd));
     }
     if (mon.isRegional && mon.isLegendary) {
-        markdown.push("<br>><br>> ### Regional Effects<br>> ", mon.regionalDescription);
+        markdown.push("<br>><br>> ### Regional Effects<br>> ", ReplaceTags(mon.regionalDescription));
         if (mon.regionals.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.regionals, false, true));
-        markdown.push("<br>><br>>", mon.regionalDescriptionEnd);
+        markdown.push("<br>><br>>", ReplaceTags(mon.regionalDescriptionEnd));
     }
 
     markdown.push("</code></body></html>")
@@ -423,7 +423,7 @@ function TryMarkdown() {
 function GetTraitMarkdown(traitArr, legendary = false, lairOrRegional = false) {
     let markdown = [];
     for (let index = 0; index < traitArr.length; index++) {
-        let desc = ReplaceTraitTags(traitArr[index].desc)
+        let desc = ReplaceTags(traitArr[index].desc)
             .replace(/(\r\n|\r|\n)\s*(\r\n|\r|\n)/g, '\n>\n')
             .replace(/(\r\n|\r|\n)>/g, '\&lt;br&gt;<br>>')
             .replace(/(\r\n|\r|\n)/g, '\&lt;br&gt;<br>> &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;');

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -1435,7 +1435,7 @@ var GetVariablesFunctions = {
     // Return the default lair description
     LairDescriptionDefault: function() {
         let monsterName = name.toLowerCase();
-        mon.lairDescription = "When fighting inside it's lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " takes a lair action to cause one of the following effects:";
+        mon.lairDescription = "When fighting inside its lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " can take one lair action to cause one of the following effects:";
     },
 
     // Return the default lair end description

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -141,7 +141,7 @@ function UpdateStatblock(moveSeparationPoint) {
 
     if (mon.isLair)
         separationMax += (mon.lairs.length == 0 ? 1 : mon.lairs.length);
-    
+
     if (mon.isRegional)
         separationMax += (mon.regionals.length == 0 ? 1 : mon.regionals.length);
 
@@ -208,15 +208,15 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.reactions.length > 0) AddToTraitList(traitsHTML, mon.reactions, "<h3>Reactions</h3>");
     if (mon.isLegendary)
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
-    if (mon.isLair && mon.isLegendary){
+    if (mon.isLair && mon.isLegendary) {
         AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
-        traitsHTML.push("*"+mon.lairDescriptionEnd);
+        traitsHTML.push("*" + mon.lairDescriptionEnd);
     }
-    if (mon.isRegional && mon.isLegendary){    
+    if (mon.isRegional && mon.isLegendary) {
         AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", mon.regionalDescription, "</div></br>"], false, true);
-        traitsHTML.push("*"+mon.regionalDescriptionEnd);
+        traitsHTML.push("*" + mon.regionalDescriptionEnd);
     }
-    
+
     // Add traits, taking into account the width of the block (one column or two columns)
     let leftTraitsArr = [],
         rightTraitsArr = [],
@@ -252,14 +252,14 @@ function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false,
     }
 
     // There's a small difference in formatting for legendary actions and lair/regional actions
-    for (let index = 0; index < traitsArr.length; index++){
-        if(isLegendary){
+    for (let index = 0; index < traitsArr.length; index++) {
+        if (isLegendary) {
             traitsHTML.push(StringFunctions.MakeTraitHTMLLegendary(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
-	    } else if (isLairRegional) {
+        } else if (isLairRegional) {
             traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegional(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
-	    } else {
+        } else {
             traitsHTML.push(StringFunctions.MakeTraitHTML(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
-	    }
+        }
     }
 }
 
@@ -592,25 +592,25 @@ var FormFunctions = {
     },
 
     ShowHideLegendaryCreature: function () {
-        if($("#is-legendary-input:checked").val()){
+        if ($("#is-legendary-input:checked").val()) {
             $("#add-legendary-button, #legendary-actions-form").show();
-            if($("#has-lair-input:checked").val())
+            if ($("#has-lair-input:checked").val())
                 $("#add-lair-button, #lair-actions-form").show();
-            if($("#has-regional-input:checked").val())
-                $("#add-regional-button, #regional-actions-form").show();           
-    } else {
+            if ($("#has-regional-input:checked").val())
+                $("#add-regional-button, #regional-actions-form").show();
+        } else {
             $("#add-legendary-button, #legendary-actions-form").hide();
             $("#add-lair-button, #add-regional-button, #lair-actions-form, #regional-actions-form").hide();
-    }
+        }
     },
 
-    ShowHideLair: function() {
+    ShowHideLair: function () {
         $("#has-lair-input:checked").val() ?
             $("#add-lair-button, #lair-actions-form").show() :
             $("#add-lair-button, #lair-actions-form").hide();
     },
 
-    ShowHideRegional: function() {
+    ShowHideRegional: function () {
         $("#has-regional-input:checked").val() ?
             $("#add-regional-button, #regional-actions-form").show() :
             $("#add-regional-button, #regional-actions-form").hide();
@@ -652,22 +652,22 @@ var FormFunctions = {
     },
 
     // For setting the lair action description
-    SetLairDescriptionForm: function() {
+    SetLairDescriptionForm: function () {
         $("#lair-descsection-input").val(mon.lairDescription);
     },
 
     // For setting the regional effect end description
-    SetLairDescriptionEndForm: function() {
+    SetLairDescriptionEndForm: function () {
         $("#lair-end-descsection-input").val(mon.lairDescriptionEnd);
     },
 
     // For setting the regional effect description
-    SetRegionalDescriptionForm: function() {
+    SetRegionalDescriptionForm: function () {
         $("#regional-descsection-input").val(mon.regionalDescription);
     },
 
     // For setting the regional effect end description
-    SetRegionalDescriptionEndForm: function() {
+    SetRegionalDescriptionEndForm: function () {
         $("#regional-end-descsection-input").val(mon.regionalDescriptionEnd);
     },
 
@@ -685,8 +685,8 @@ var FormFunctions = {
 
     // Make a list of removable items and add it to the editor
     MakeDisplayList: function (arrName, capitalize, isBlock = false) {
-    if (typeof mon[arrName] == 'undefined')
-        mon[arrName] = [];
+        if (typeof mon[arrName] == 'undefined')
+            mon[arrName] = [];
         let arr = (arrName == "damage" ? mon.damagetypes.concat(mon.specialdamage) : mon[arrName]),
             displayArr = [],
             content = "",
@@ -862,7 +862,7 @@ var InputFunctions = {
     },
 
     // Reset lair description to default
-    LairDescriptionDefaultInput: function() {
+    LairDescriptionDefaultInput: function () {
         GetVariablesFunctions.LairDescriptionDefault();
         FormFunctions.SetLairDescriptionForm();
         GetVariablesFunctions.LairDescriptionEndDefault();
@@ -870,7 +870,7 @@ var InputFunctions = {
     },
 
     // Reset regional description to default
-    RegionalDescriptionDefaultInput: function() {
+    RegionalDescriptionDefaultInput: function () {
         GetVariablesFunctions.RegionalDescriptionDefault();
         FormFunctions.SetRegionalDescriptionForm();
         GetVariablesFunctions.RegionalDescriptionEndDefault();
@@ -955,14 +955,14 @@ var GetVariablesFunctions = {
 
         // Lair
         mon.isLair = $("#has-lair-input").prop("checked");
-        if (mon.isLair){
+        if (mon.isLair) {
             mon.lairDescription = $("#lair-descsection-input").val().trim();
             mon.lairDescriptionEnd = $("#lair-end-descsection-input").val().trim();
         }
 
         // Regional
         mon.isRegional = $("#has-regional-input").prop("checked");
-        if (mon.isRegional){
+        if (mon.isRegional) {
             mon.regionalDescription = $("#regional-descsection-input").val().trim();
             mon.regionalDescriptionEnd = $("#regional-end-descsection-input").val().trim();
         }
@@ -1194,11 +1194,11 @@ var GetVariablesFunctions = {
 
         // Lair?
         mon.isLair = Array.isArray(preset.lair_actions);
-        if (preset.lair_desc == null || preset.lair_desc.length == 0){
+        if (preset.lair_desc == null || preset.lair_desc.length == 0) {
             this.LairDescriptionDefault();
             this.LairDescriptionEndDefault();
         }
-        else{
+        else {
             mon.lairDescription = preset.lair_desc;
             mon.lairDescriptionEnd = preset.lair_desc_end;
         }
@@ -1206,11 +1206,11 @@ var GetVariablesFunctions = {
 
         // Regional Effects?
         mon.isRegional = Array.isArray(preset.regional_actions);
-        if (preset.regional_desc == null || preset.regional_desc.length == 0){
+        if (preset.regional_desc == null || preset.regional_desc.length == 0) {
             this.RegionalDescriptionDefault();
             this.RegionalDescriptionEndDefault();
         }
-        else{
+        else {
             mon.regionalDescription = preset.regional_desc;
             mon.regionalDescriptionEnd = preset.regional_desc_end;
         }
@@ -1433,25 +1433,25 @@ var GetVariablesFunctions = {
     },
 
     // Return the default lair description
-    LairDescriptionDefault: function() {
+    LairDescriptionDefault: function () {
         let monsterName = name.toLowerCase();
         mon.lairDescription = "When fighting inside its lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " can take one lair action to cause one of the following effects:";
     },
 
     // Return the default lair end description
-    LairDescriptionEndDefault: function() {
+    LairDescriptionEndDefault: function () {
         let monsterName = name.toLowerCase();
         mon.lairDescriptionEnd = "The " + mon.name.toLowerCase() + " can't repeat an effect until they have all been used, and it can't use the same effect two rounds in a row.";
     },
 
     // Return the default regional description
-    RegionalDescriptionDefault: function() {
+    RegionalDescriptionDefault: function () {
         let monsterName = name.toLowerCase();
         mon.regionalDescription = "The region containing the " + mon.name.toLowerCase() + "'s lair is warped by the creature's presence, which creates one or more of the following effects:";
     },
 
     // Return the default regional end description
-    RegionalDescriptionEndDefault: function() {
+    RegionalDescriptionEndDefault: function () {
         let monsterName = name.toLowerCase();
         mon.regionalDescriptionEnd = "If the " + mon.name.toLowerCase() + " dies, the first two effects fade over the course of 3d10 days.";
     }
@@ -1685,7 +1685,7 @@ var StringFunctions = {
         return "<div class=\"property-block reverse-indent legendary\"><div><h4>" + name + ".</h4><p> " + this.FormatString(description, true) + "</p></div></div> <!-- property block -->";
     },
 
-    MakeTraitHTMLLairRegional: function(name, description) {
+    MakeTraitHTMLLairRegional: function (name, description) {
         return "<div class=\"property-block lairregional\"><div><ul><li>" + this.FormatString(description, true) + "</li></ul></div></div> <!-- property block -->";
     },
 

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -42,6 +42,7 @@ var mon = {
     lairDescription: "",
     isRegional: false,
     regionalDescription: "",
+    regionalDescriptionEnd: "",
     properties: [],
     abilities: [],
     actions: [],
@@ -208,8 +209,10 @@ function UpdateStatblock(moveSeparationPoint) {
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
     if (mon.isLair && mon.isLegendary)
         AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
-    if (mon.isRegional && mon.isLegendary)    
+    if (mon.isRegional && mon.isLegendary){    
         AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", mon.regionalDescription, "</div></br>"], false, true);
+        traitsHTML.push("*"+mon.regionalDescriptionEnd);
+    }
     
     // Add traits, taking into account the width of the block (one column or two columns)
     let leftTraitsArr = [],
@@ -405,6 +408,7 @@ function TryMarkdown() {
     if (mon.isRegional && mon.isLegendary) {
         markdown.push("<br>><br>> ### Regional Effects<br>> ", mon.regionalDescription);
         if (mon.regionals.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.regionals, false, true));
+        markdown.push("<br>><br>>", mon.regionalDescriptionEnd);
     }
 
     markdown.push("</code></body></html>")
@@ -653,6 +657,11 @@ var FormFunctions = {
         $("#regional-descsection-input").val(mon.regionalDescription);
     },
 
+    // For setting the regional effect end description
+    SetRegionalDescriptionEndForm: function() {
+        $("#regional-end-descsection-input").val(mon.regionalDescriptionEnd);
+    },
+
     SetCommonAbilitiesDropdown: function () {
         $("#common-ability-input").html("");
         for (let index = 0; index < data.commonAbilities.length; index++)
@@ -853,6 +862,8 @@ var InputFunctions = {
     RegionalDescriptionDefaultInput: function() {
         GetVariablesFunctions.RegionalDescriptionDefault();
         FormFunctions.SetRegionalDescriptionForm();
+        GetVariablesFunctions.RegionalDescriptionEndDefault();
+        FormFunctions.SetRegionalDescriptionEndForm();
     },
 
     AddCommonAbilityInput: function () {
@@ -941,6 +952,7 @@ var GetVariablesFunctions = {
         mon.isRegional = $("#has-regional-input").prop("checked");
         if (mon.isRegional){
             mon.regionalDescription = $("#regional-descsection-input").val().trim();
+            mon.regionalDescriptionEnd = $("#regional-end-descsection-input").val().trim();
         }
 
         // One or two columns ?
@@ -1178,11 +1190,16 @@ var GetVariablesFunctions = {
 
         // Regional Effects?
         mon.isRegional = Array.isArray(preset.regional_actions);
-        if (preset.regional_desc == null || preset.regional_desc.length == 0)
+        if (preset.regional_desc == null || preset.regional_desc.length == 0){
             this.RegionalDescriptionDefault();
-        else
+            this.RegionalDescriptionEndDefault();
+        }
+        else{
             mon.regionalDescription = preset.regional_desc;
+            mon.regionalDescriptionEnd = preset.regional_desc_end;
+        }
         FormFunctions.SetRegionalDescriptionForm();
+        FormFunctions.SetRegionalDescriptionEndForm();
 
         // Abilities
         mon.abilities = [];
@@ -1409,6 +1426,12 @@ var GetVariablesFunctions = {
     RegionalDescriptionDefault: function() {
         let monsterName = name.toLowerCase();
         mon.regionalDescription = "The region containing the " + mon.name.toLowerCase() + "'s lair is warped by the creature's presence, which creates one or more of the following effects:";
+    },
+
+    // Return the default regional end description
+    RegionalDescriptionEndDefault: function() {
+        let monsterName = name.toLowerCase();
+        mon.regionalDescriptionEnd = "If the " + mon.name.toLowerCase() + " dies, the first two effects fade over the course of 3d10 days.";
     }
 }
 
@@ -1783,6 +1806,7 @@ function Populate() {
     FormFunctions.SetLegendaryDescriptionForm();
     FormFunctions.SetLairDescriptionForm();
     FormFunctions.SetRegionalDescriptionForm();
+    FormFunctions.SetRegionalDescriptionEndForm();
     FormFunctions.SetCommonAbilitiesDropdown();
 
     // Populate the stat block

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -38,11 +38,17 @@ var mon = {
     customProf: 2,
     isLegendary: false,
     legendariesDescription: "",
+    isLair: false,
+    lairDescription: "",
+    isRegion: false,
+    regionDescription: "",
     properties: [],
     abilities: [],
     actions: [],
     reactions: [],
     legendaries: [],
+    lairs: [],
+    regions: [],
     sthrows: [],
     skills: [],
     damagetypes: [],
@@ -131,6 +137,12 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.isLegendary)
         separationMax += (mon.legendaries.length == 0 ? 1 : mon.legendaries.length);
 
+    if (mon.isLair)
+        separationMax += (mon.lairs.length == 0 ? 1 : mon.lairs.length);
+    
+    if (mon.isRegion)
+        separationMax += (mon.regions.length == 0 ? 1 : mon.regions.length);
+
     if (mon.separationPoint == undefined)
         mon.separationPoint = Math.floor(separationMax / 2);
 
@@ -194,7 +206,11 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.reactions.length > 0) AddToTraitList(traitsHTML, mon.reactions, "<h3>Reactions</h3>");
     if (mon.isLegendary)
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
-
+    if (mon.isLair && mon.isLegendary)
+        AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
+    if (mon.isRegion && mon.isLegendary)    
+        AddToTraitList(traitsHTML, mon.regions, mon.regionDescription == "" ? "<h3>Region Effects</h3>" : ["<h3>Region Effects</h3><div class='property-block'>", mon.regionDescription, "</div></br>"], false, true);
+    
     // Add traits, taking into account the width of the block (one column or two columns)
     let leftTraitsArr = [],
         rightTraitsArr = [],
@@ -218,7 +234,7 @@ function UpdateStatblock(moveSeparationPoint) {
 }
 
 // Function used by UpdateStatblock for abilities
-function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false) {
+function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false, isLairRegion = false) {
 
     // Add specific elements to the beginning of the array, usually a header
     if (addElements != undefined) {
@@ -229,9 +245,16 @@ function AddToTraitList(traitsHTML, traitsArr, addElements, isLegendary = false)
             traitsHTML.push("*" + addElements);
     }
 
-    // There's a small difference in formatting for legendary actions
-    for (let index = 0; index < traitsArr.length; index++)
-        traitsHTML.push(StringFunctions[isLegendary ? "MakeTraitHTMLLegendary" : "MakeTraitHTML"](traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+    // There's a small difference in formatting for legendary actions and lair/region actions
+    for (let index = 0; index < traitsArr.length; index++){
+        if(isLegendary){
+            traitsHTML.push(StringFunctions.MakeTraitHTMLLegendary(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+	    } else if (isLairRegion) {
+            traitsHTML.push(StringFunctions.MakeTraitHTMLLairRegion(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+	    } else {
+            traitsHTML.push(StringFunctions.MakeTraitHTML(traitsArr[index].name, ReplaceTraitTags(traitsArr[index].desc)));
+	    }
+    }
 }
 
 function ReplaceTraitTags(desc) {
@@ -375,13 +398,21 @@ function TryMarkdown() {
         markdown.push("<br>> ### Legendary Actions<br>> ", mon.legendariesDescription);
         if (mon.legendaries.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.legendaries, true));
     }
+    if (mon.isLair && mon.isLegendary) {
+        markdown.push("<br>> ### Lair Actions<br>> ", mon.lairDescription);
+        if (mon.lairs.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.lairs, false, true));
+    }
+    if (mon.isRegion && mon.isLegendary) {
+        markdown.push("<br>><br>> ### Region Effects<br>> ", mon.regionDescription);
+        if (mon.regions.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.regions, false, true));
+    }
 
     markdown.push("</code></body></html>")
 
     markdownWindow.document.write(markdown.join(""));
 }
 
-function GetTraitMarkdown(traitArr, legendary) {
+function GetTraitMarkdown(traitArr, legendary = false, lairOrRegion = false) {
     let markdown = [];
     for (let index = 0; index < traitArr.length; index++) {
         let desc = ReplaceTraitTags(traitArr[index].desc)
@@ -389,9 +420,9 @@ function GetTraitMarkdown(traitArr, legendary) {
             .replace(/(\r\n|\r|\n)>/g, '\&lt;br&gt;<br>>')
             .replace(/(\r\n|\r|\n)/g, '\&lt;br&gt;<br>> &amp;nbsp;&amp;nbsp;&amp;nbsp;&amp;nbsp;');
         markdown.push("> " +
-            (legendary ? "**" : "***") +
-            traitArr[index].name +
-            (legendary ? ".** " : ".*** ") +
+            (legendary ? "**" : (lairOrRegion ? "* " : "***")) +
+            (lairOrRegion ? "" : traitArr[index].name) +
+            (legendary ? ".** " : lairOrRegion ? "" : (".*** ")) +
             desc);
     }
     return markdown.join("<br>><br>");
@@ -475,10 +506,20 @@ var FormFunctions = {
         this.MakeDisplayList("actions", false, true);
         this.MakeDisplayList("reactions", false, true);
         this.MakeDisplayList("legendaries", false, true);
+        this.MakeDisplayList("lairs", false, true);
+        this.MakeDisplayList("regions", false, true);
 
         // Is Legendary?	
         $("#is-legendary-input").prop("checked", mon.isLegendary);
         this.ShowHideLegendaryCreature();
+
+        // Is Lair?	
+        $("#has-lair-input").prop("checked", mon.isLair);
+        this.ShowHideLair();
+
+        // Is Region?	
+        $("#has-region-input").prop("checked", mon.isRegion);
+        this.ShowHideRegion();
 
         // Challenge Rating
         $("#cr-input").val(mon.cr);
@@ -543,9 +584,28 @@ var FormFunctions = {
     },
 
     ShowHideLegendaryCreature: function () {
-        $("#is-legendary-input:checked").val() ?
-            $("#add-legendary-button, #legendary-actions-form").show() :
+        if($("#is-legendary-input:checked").val()){
+            $("#add-legendary-button, #legendary-actions-form").show();
+            if($("#has-lair-input:checked").val())
+                $("#add-lair-button, #lair-actions-form").show();
+            if($("#has-region-input:checked").val())
+                $("#add-region-button, #region-actions-form").show();           
+    } else {
             $("#add-legendary-button, #legendary-actions-form").hide();
+            $("#add-lair-button, #add-region-button, #lair-actions-form, #region-actions-form").hide();
+    }
+    },
+
+    ShowHideLair: function() {
+        $("#has-lair-input:checked").val() ?
+            $("#add-lair-button, #lair-actions-form").show() :
+            $("#add-lair-button, #lair-actions-form").hide();
+    },
+
+    ShowHideRegion: function() {
+        $("#has-region-input:checked").val() ?
+            $("#add-region-button, #region-actions-form").show() :
+            $("#add-region-button, #region-actions-form").hide();
     },
 
     ShowHideFormatHelper: function () {
@@ -583,6 +643,16 @@ var FormFunctions = {
         $("#legendaries-descsection-input").val(mon.legendariesDescription);
     },
 
+    // For setting the lair action description
+    SetLairDescriptionForm: function() {
+        $("#lair-descsection-input").val(mon.lairDescription);
+    },
+
+    // For setting the region effect description
+    SetRegionDescriptionForm: function() {
+        $("#region-descsection-input").val(mon.regionDescription);
+    },
+
     SetCommonAbilitiesDropdown: function () {
         $("#common-ability-input").html("");
         for (let index = 0; index < data.commonAbilities.length; index++)
@@ -597,6 +667,8 @@ var FormFunctions = {
 
     // Make a list of removable items and add it to the editor
     MakeDisplayList: function (arrName, capitalize, isBlock = false) {
+    if (typeof mon[arrName] == 'undefined')
+        mon[arrName] = [];
         let arr = (arrName == "damage" ? mon.damagetypes.concat(mon.specialdamage) : mon[arrName]),
             displayArr = [],
             content = "",
@@ -771,6 +843,18 @@ var InputFunctions = {
         FormFunctions.SetLegendaryDescriptionForm();
     },
 
+    // Reset lair description to default
+    LairDescriptionDefaultInput: function() {
+        GetVariablesFunctions.LairDescriptionDefault();
+        FormFunctions.SetLairDescriptionForm();
+    },
+
+    // Reset region description to default
+    RegionDescriptionDefaultInput: function() {
+        GetVariablesFunctions.RegionDescriptionDefault();
+        FormFunctions.SetRegionDescriptionForm();
+    },
+
     AddCommonAbilityInput: function () {
         let commonAbility = data.commonAbilities[$("#common-ability-input").val()];
         if (commonAbility.desc) {
@@ -846,6 +930,18 @@ var GetVariablesFunctions = {
         mon.isLegendary = $("#is-legendary-input").prop("checked");
         if (mon.isLegendary)
             mon.legendariesDescription = $("#legendaries-descsection-input").val().trim();
+
+        // Lair
+        mon.isLair = $("#has-lair-input").prop("checked");
+        if (mon.isLair){
+            mon.lairDescription = $("#lair-descsection-input").val().trim();
+        }
+
+        // Region
+        mon.isRegion = $("#has-region-input").prop("checked");
+        if (mon.isRegion){
+            mon.regionDescription = $("#region-descsection-input").val().trim();
+        }
 
         // One or two columns ?
         mon.doubleColumns = $("#2col-input").prop("checked");
@@ -1072,15 +1168,35 @@ var GetVariablesFunctions = {
             mon.legendariesDescription = preset.legendary_desc;
         FormFunctions.SetLegendaryDescriptionForm();
 
+        // Lair?
+        mon.isLair = Array.isArray(preset.lair_actions);
+        if (preset.lair_desc == null || preset.lair_desc.length == 0)
+            this.LairDescriptionDefault();
+        else
+            mon.lairDescription = preset.lair_desc;
+        FormFunctions.SetLairDescriptionForm();
+
+        // Region Effects?
+        mon.isRegion = Array.isArray(preset.region_actions);
+        if (preset.region_desc == null || preset.region_desc.length == 0)
+            this.RegionDescriptionDefault();
+        else
+            mon.regionDescription = preset.region_desc;
+        FormFunctions.SetRegionDescriptionForm();
+
         // Abilities
         mon.abilities = [];
         mon.actions = [];
         mon.reactions = [];
         mon.legendaries = [];
+        mon.lairs = [];
+        mon.regions = [];
         let abilitiesPresetArr = preset.special_abilities,
             actionsPresetArr = preset.actions,
             reactionsPresetArr = preset.reactions,
-            legendariesPresetArr = preset.legendary_actions;
+            legendariesPresetArr = preset.legendary_actions,
+            lairsPresetArr = preset.lair_actions,
+            regionsPresetArr = preset.region_actions;
 
         let self = this,
             AbilityPresetLoop = function (arr, name) {
@@ -1095,6 +1211,10 @@ var GetVariablesFunctions = {
         AbilityPresetLoop(reactionsPresetArr, "reactions");
         if (mon.isLegendary)
             AbilityPresetLoop(legendariesPresetArr, "legendaries");
+        if (mon.isLair)
+            AbilityPresetLoop(lairsPresetArr, "lairs");
+        if (mon.isRegion)
+            AbilityPresetLoop(regionsPresetArr, "regions");
 
         mon.separationPoint = undefined; // This will make the separation point be automatically calculated in UpdateStatblock
     },
@@ -1277,6 +1397,18 @@ var GetVariablesFunctions = {
     LegendaryDescriptionDefault: function () {
         let monsterName = name.toLowerCase();
         mon.legendariesDescription = "The " + mon.name.toLowerCase() + " can take 3 legendary actions, choosing from the options below. Only one legendary action option can be used at a time and only at the end of another creature's turn. The " + mon.name.toLowerCase() + " regains spent legendary actions at the start of its turn.";
+    },
+
+    // Return the default lair description
+    LairDescriptionDefault: function() {
+        let monsterName = name.toLowerCase();
+        mon.lairDescription = "When fighting inside it's lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " takes a lair action to cause one of the following effects:";
+    },
+
+    // Return the default region description
+    RegionDescriptionDefault: function() {
+        let monsterName = name.toLowerCase();
+        mon.regionDescription = "The region containing the " + mon.name.toLowerCase() + "'s lair is warped by the creature's presence, which creates one or more of the following effects:";
     }
 }
 
@@ -1508,6 +1640,10 @@ var StringFunctions = {
         return "<div class=\"property-block reverse-indent legendary\"><div><h4>" + name + ".</h4><p> " + this.FormatString(description, true) + "</p></div></div> <!-- property block -->";
     },
 
+    MakeTraitHTMLLairRegion: function(name, description) {
+        return "<div class=\"property-block lairregion\"><div><ul><li>" + this.FormatString(description, true) + "</li></ul></div></div> <!-- property block -->";
+    },
+
     // General string operations
 
     ConcatUnlessEmpty(item1, item2, joinString = ", ") {
@@ -1645,6 +1781,8 @@ $(function () {
 
 function Populate() {
     FormFunctions.SetLegendaryDescriptionForm();
+    FormFunctions.SetLairDescriptionForm();
+    FormFunctions.SetRegionDescriptionForm();
     FormFunctions.SetCommonAbilitiesDropdown();
 
     // Populate the stat block

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -209,12 +209,12 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.isLegendary)
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", ReplaceTags(mon.legendariesDescription), "</div></br>"], true);
     if (mon.isLair && mon.isLegendary) {
-        AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", ReplaceTags(mon.lairDescription), "</div></br>"], false, true);
-        traitsHTML.push("*" + ReplaceTags(mon.lairDescriptionEnd));
+        AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", ReplaceTags(mon.lairDescription), "</div></br><ul>"], false, true);
+        traitsHTML.push("</ul>" + ReplaceTags(mon.lairDescriptionEnd));
     }
     if (mon.isRegional && mon.isLegendary) {
-        AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", ReplaceTags(mon.regionalDescription), "</div></br>"], false, true);
-        traitsHTML.push("*" + ReplaceTags(mon.regionalDescriptionEnd));
+        AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", ReplaceTags(mon.regionalDescription), "</div></br><ul>"], false, true);
+        traitsHTML.push("</ul>" + ReplaceTags(mon.regionalDescriptionEnd));
     }
 
     // Add traits, taking into account the width of the block (one column or two columns)
@@ -1686,7 +1686,7 @@ var StringFunctions = {
     },
 
     MakeTraitHTMLLairRegional: function (name, description) {
-        return "<div class=\"property-block lairregional\"><div><ul><li>" + this.FormatString(description, true) + "</li></ul></div></div> <!-- property block -->";
+        return "<div class=\"property-block lairregional\"><div><li>" + this.FormatString(description, true) + "</li></div></div> <!-- property block -->";
     },
 
     // General string operations

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -40,6 +40,7 @@ var mon = {
     legendariesDescription: "",
     isLair: false,
     lairDescription: "",
+    lairDescriptionEnd: "",
     isRegional: false,
     regionalDescription: "",
     regionalDescriptionEnd: "",
@@ -207,8 +208,10 @@ function UpdateStatblock(moveSeparationPoint) {
     if (mon.reactions.length > 0) AddToTraitList(traitsHTML, mon.reactions, "<h3>Reactions</h3>");
     if (mon.isLegendary)
         AddToTraitList(traitsHTML, mon.legendaries, mon.legendariesDescription == "" ? "<h3>Legendary Actions</h3>" : ["<h3>Legendary Actions</h3><div class='property-block'>", mon.legendariesDescription, "</div></br>"], true);
-    if (mon.isLair && mon.isLegendary)
+    if (mon.isLair && mon.isLegendary){
         AddToTraitList(traitsHTML, mon.lairs, mon.lairDescription == "" ? "<h3>Lair Actions</h3>" : ["<h3>Lair Actions</h3><div class='property-block'>", mon.lairDescription, "</div></br>"], false, true);
+        traitsHTML.push("*"+mon.lairDescriptionEnd);
+    }
     if (mon.isRegional && mon.isLegendary){    
         AddToTraitList(traitsHTML, mon.regionals, mon.regionalDescription == "" ? "<h3>Regional Effects</h3>" : ["<h3>Regional Effects</h3><div class='property-block'>", mon.regionalDescription, "</div></br>"], false, true);
         traitsHTML.push("*"+mon.regionalDescriptionEnd);
@@ -404,6 +407,7 @@ function TryMarkdown() {
     if (mon.isLair && mon.isLegendary) {
         markdown.push("<br>> ### Lair Actions<br>> ", mon.lairDescription);
         if (mon.lairs.length > 0) markdown.push("<br>><br>", GetTraitMarkdown(mon.lairs, false, true));
+        markdown.push("<br>><br>>", mon.lairDescriptionEnd);
     }
     if (mon.isRegional && mon.isLegendary) {
         markdown.push("<br>><br>> ### Regional Effects<br>> ", mon.regionalDescription);
@@ -652,6 +656,11 @@ var FormFunctions = {
         $("#lair-descsection-input").val(mon.lairDescription);
     },
 
+    // For setting the regional effect end description
+    SetLairDescriptionEndForm: function() {
+        $("#lair-end-descsection-input").val(mon.lairDescriptionEnd);
+    },
+
     // For setting the regional effect description
     SetRegionalDescriptionForm: function() {
         $("#regional-descsection-input").val(mon.regionalDescription);
@@ -856,6 +865,8 @@ var InputFunctions = {
     LairDescriptionDefaultInput: function() {
         GetVariablesFunctions.LairDescriptionDefault();
         FormFunctions.SetLairDescriptionForm();
+        GetVariablesFunctions.LairDescriptionEndDefault();
+        FormFunctions.SetLairDescriptionEndForm();
     },
 
     // Reset regional description to default
@@ -946,6 +957,7 @@ var GetVariablesFunctions = {
         mon.isLair = $("#has-lair-input").prop("checked");
         if (mon.isLair){
             mon.lairDescription = $("#lair-descsection-input").val().trim();
+            mon.lairDescriptionEnd = $("#lair-end-descsection-input").val().trim();
         }
 
         // Regional
@@ -1182,10 +1194,14 @@ var GetVariablesFunctions = {
 
         // Lair?
         mon.isLair = Array.isArray(preset.lair_actions);
-        if (preset.lair_desc == null || preset.lair_desc.length == 0)
+        if (preset.lair_desc == null || preset.lair_desc.length == 0){
             this.LairDescriptionDefault();
-        else
+            this.LairDescriptionEndDefault();
+        }
+        else{
             mon.lairDescription = preset.lair_desc;
+            mon.lairDescriptionEnd = preset.lair_desc_end;
+        }
         FormFunctions.SetLairDescriptionForm();
 
         // Regional Effects?
@@ -1420,6 +1436,12 @@ var GetVariablesFunctions = {
     LairDescriptionDefault: function() {
         let monsterName = name.toLowerCase();
         mon.lairDescription = "When fighting inside it's lair, the " + mon.name.toLowerCase() + " can invoke the ambient magic to take lair actions. On initiative count 20 (losing initiative ties), the " + mon.name.toLowerCase() + " takes a lair action to cause one of the following effects:";
+    },
+
+    // Return the default lair end description
+    LairDescriptionEndDefault: function() {
+        let monsterName = name.toLowerCase();
+        mon.lairDescriptionEnd = "The " + mon.name.toLowerCase() + " can't repeat an effect until they have all been used, and it can't use the same effect two rounds in a row.";
     },
 
     // Return the default regional description
@@ -1805,6 +1827,7 @@ $(function () {
 function Populate() {
     FormFunctions.SetLegendaryDescriptionForm();
     FormFunctions.SetLairDescriptionForm();
+    FormFunctions.SetLairDescriptionEndForm();
     FormFunctions.SetRegionalDescriptionForm();
     FormFunctions.SetRegionalDescriptionEndForm();
     FormFunctions.SetCommonAbilitiesDropdown();


### PR DESCRIPTION
Added Lair Actions and Region Effects entry fields (based on issue https://github.com/Tetra-cube/Tetra-cube.github.io/issues/7).

- Save to file, Print, Image, and Markdown export supported and tested
- Auto hide Lair and Region tied to Legendary State
- Backwards compatible with importing earlier .monster files and preset loading without lair or region details