### PR TITLE
Statblock generator: Print colored statblocks

### DIFF
--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -57,7 +57,12 @@
             <br>
             <button onclick="TrySaveFile()">Save Statblock</button>
             <button onclick="LoadFilePrompt()">Load Statblock</button>
-            <button onclick="TryPrint()">Printable Block</button>
+            <span style="display: inline-table;">
+                <button onclick="TryPrint()">Printable Block</button>
+                <br>
+                <input id="print-color-mode" type="checkbox">
+                <label for="print-color-mode" title="Print the statblock shown below if checked, or a black-and-white version if not.">Color mode</label>
+            </span>
             <button onclick="TryImage()">View Image</button>
             <button onclick="TryMarkdown()">View Markdown</button>
             <input id="file-upload" type="file" onChange="TryLoadFile();" hidden />

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -92,8 +92,9 @@ var TryLoadFile = () => {
 
 // Print function
 function TryPrint() {
+    let colorMode = $("#print-color-mode").is(":checked");
     let printWindow = window.open();
-    printWindow.document.write('<html><head><meta charset="utf-8"/><title>' + mon.name + '</title><link rel="shortcut icon" type="image/x-icon" href="./dndimages/favicon.ico" /><link rel="stylesheet" type="text/css" href="css/statblock-style.css"><link rel="stylesheet" type="text/css" href="css/libre-baskerville.css"><link rel="stylesheet" type="text/css" href="css/noto-sans.css"></head><body><div id="print-block" class="content">');
+    printWindow.document.write('<html><head><meta charset="utf-8"/><title>' + mon.name + '</title><link rel="shortcut icon" type="image/x-icon" href="./dndimages/favicon.ico" /><link rel="stylesheet" type="text/css" href="css/statblock-style.css"><link rel="stylesheet" type="text/css" href="css/libre-baskerville.css"><link rel="stylesheet" type="text/css" href="css/noto-sans.css"></head><body><div id="' + (colorMode?'stat-block-wrapper':'print-block') + '" class="content">');
     printWindow.document.write($("#stat-block-wrapper").html());
     printWindow.document.write('</div></body></html>');
 }


### PR DESCRIPTION
Added a checkbox below the "Printable Block" button that will open the actually shown statblock in the print tab if checked. Remember that you might have to turn on the "print background [graphics]" option in the browser's print dialog.

This will also allow clean PDF exporting (and then further conversion to SVG and/or high-resolution PNGs, if needed).