### PR TITLE
Statblock generator: Print multiple statblocks at a time

### DIFF
--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -1,6 +1,6 @@
 .fa {
     cursor: pointer;
-    transition: .1s
+    transition: .5s
 }
 
 .fa:not(.disabled):hover {

--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -1,0 +1,27 @@
+.fa {
+    cursor: pointer;
+    transition: .1s
+}
+
+.fa:not(.disabled):hover {
+    color: darkred;
+}
+
+.fa.disabled {
+    opacity: .5;
+    cursor: default;
+}
+
+#print-options {
+    text-align: left;
+    left: 25%;
+}
+
+#print-preview {
+    background-color: white;
+    box-shadow: 0 0 1.5rem #867453;
+    margin-top: 1.5rem;
+    overflow-y: auto;
+    /* demo only */
+    height: 200px;
+}

--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -21,7 +21,9 @@
     background-color: white;
     box-shadow: 0 0 1.5rem #867453;
     margin-top: 1.5rem;
-    overflow-y: auto;
+    padding: 5px;
+    text-align: left;
+    /* overflow-y: auto; */
     /* demo only */
-    height: 200px;
+    /* height: 200px; */
 }

--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -34,3 +34,29 @@ i.fa.disabled {
     height: unset;
     width: unset;
 }
+
+#dragndrop-overlay {
+    background-color: rgba(255,255,255,0.5);
+    position: fixed;
+    width: 100%;
+    height: 100%;
+    user-select: none;
+    text-align: center;
+    font-size: 2.5rem;
+}
+
+#dragndrop-overlay > div {
+    margin: 0;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+#dragndrop-overlay .fa {
+    font-size: 10rem;
+}
+
+.hidden {
+    display: none;
+}

--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -1,13 +1,13 @@
-.fa {
+i.fa {
     cursor: pointer;
     transition: .5s
 }
 
-.fa:not(.disabled):hover {
+i.fa:not(.disabled):hover {
     color: darkred;
 }
 
-.fa.disabled {
+i.fa.disabled {
     opacity: .5;
     cursor: default;
 }
@@ -23,7 +23,14 @@
     margin-top: 1.5rem;
     padding: 5px;
     text-align: left;
-    /* overflow-y: auto; */
-    /* demo only */
-    /* height: 200px; */
+    overflow-x: auto;
+}
+
+#statblocks-list {
+    list-style-type: none;
+}
+
+#print-margin-input {
+    height: unset;
+    width: unset;
 }

--- a/dnd/css/statblock-print-style.css
+++ b/dnd/css/statblock-print-style.css
@@ -17,7 +17,7 @@ i.fa.disabled {
     left: 25%;
 }
 
-#print-preview {
+#print-preview-page {
     background-color: white;
     box-shadow: 0 0 1.5rem #867453;
     margin-top: 1.5rem;

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -21,6 +21,12 @@
 </head>
 
 <body id="stat-block-body" style="min-width: 1000px;">
+    <div id="dragndrop-overlay" class="hidden">
+        <div>
+            <span class="fa fa-sign-in-alt fa-rotate-90"></span><br>
+            Drop here
+        </div>
+    </div>
     <div class="container" style="text-align: center;">
         <div class="content">
             <a href="dnd-statblock.html"><img class="statblock-image" src="dndimages/edit-icon.png">&nbsp;Back to the
@@ -28,7 +34,7 @@
             <h1>Statblock printer</h1>
             <p>Print multiple statblocks on one sheet of paper.</p>
 
-            <button onclick="$('#file-upload').click()">Load Statblock(s)...</button>
+            <button onclick="$('#file-upload').click()">Load Statblock(s)...</button> or drag & drop
             <input id="file-upload" type="file" onChange="addStatblock()" hidden multiple/>
             <div id="monster-select-form">SRD/Tome of Beasts statblocks: 
                 <select id="monster-select">

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -67,14 +67,14 @@
             <p><b><i>Hint:</i></b> You can toggle the background graphics of the statblocks in your browser's print dialog.
             </p>
             <div id="print-options">
-                <input id="monochrome-print" type="checkbox" onchange="updatePrintOptions()">
-                <label for="monochrome-print">Monochrome statblocks</label>
+                <input id="monochrome-print-input" type="checkbox" onchange="updatePrintOptions()">
+                <label for="monochrome-print-input">Monochrome statblocks</label>
                 <br>
-                <input id="save-paper" type="checkbox" onchange="updatePrintOptions()">
-                <label for="save-paper">Align two adjacent single-column statblocks next to each other</label>
+                <input id="save-paper-input" type="checkbox" onchange="updatePrintOptions()">
+                <label for="save-paper-input">Align two adjacent single-column statblocks next to each other</label>
                 <br>
-                <label for="print-margin">Margin between the statblocks: </label>
-                <input id="print-margin" type="number" onchange="updatePrintOptions()"> px
+                <label for="print-margin-input">Margin between the statblocks: </label>
+                <input id="print-margin-input" type="number" onchange="updatePrintOptions()"> px
                 <br>
                 <button onclick="printBlocks()">Print</button>
             </div>

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -41,7 +41,7 @@
             <p><b><i>Hint:</i></b> You can toggle the background graphics of the statblocks in your browser's print dialog.
             </p>
             <div id="print-options">
-                <input id="monochrome-print-input" type="checkbox" onchange="updatePrintOptions()">
+                <input id="monochrome-print-input" type="checkbox" onchange="refresh()">
                 <label for="monochrome-print-input">Monochrome statblocks</label>
                 <br>
                 <input id="save-paper-input" type="checkbox" checked onchange="refresh()">

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Statblock printer</title>
+    <link rel="shortcut icon" type="image/x-icon" href="dndimages/favicon.ico" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="css/statblock-style.css">
+    <link rel="stylesheet" type="text/css" href="css/statblock-page-style.css">
+    <link rel="stylesheet" type="text/css" href="css/dnd-style.css">
+    <link rel="stylesheet" type="text/css" href="css/libre-baskerville.css">
+    <link rel="stylesheet" type="text/css" href="css/noto-sans.css">
+    <link rel="stylesheet" type="text/css" href="css/statblock-print-style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <script src="js/jquery-3.4.1.min.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/FileSaver.min.js"></script>
+    <script src="js/dom-to-image.min.js"></script>
+    <script src="js/statblock-script.js"></script>
+</head>
+
+<body id="stat-block-body" style="min-width: 1000px;">
+    <div class="container" style="text-align: center;">
+        <div class="content">
+            <a href="dnd-statblock.html"><img class="statblock-image" src="dndimages/edit-icon.png">&nbsp;Back to the
+                Statblock editor</a>
+            <h1>Statblock printer</h1>
+            <p>Print multiple statblocks on one sheet of paper.</p>
+
+            <div style="text-align: left; padding: 25px 0px;">
+                <h3>Included statblocks
+                    <button onclick="addStatblock()">Load...</button>
+                </h3>
+                <ul id="statblocks-list">
+                    <!-- Sample Data -->
+                    <li>
+                        <i class="fa fa-arrow-up disabled" title="Up" onclick=""></i>
+                        <i class="fa fa-arrow-down" title="Down" onclick=""></i>
+                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
+                        <i class="fa fa-clone" title="Clone" onclick=""></i>
+                        <i class="fa fa-download" title="Download" onclick=""></i>
+                        <b>Drakeling</b> <i>Small dragon, unaligned</i>
+                    </li>
+                    <li>
+                        <i class="fa fa-arrow-up" title="Up" onclick=""></i>
+                        <i class="fa fa-arrow-down" title="Down" onclick=""></i>
+                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
+                        <i class="fa fa-clone" title="Clone" onclick=""></i>
+                        <i class="fa fa-download" title="Download" onclick=""></i>
+                        <b>Fox</b> <i>Small beast, unaligned</i>
+                    </li>
+                    <li>
+                        <i class="fa fa-arrow-up" title="Up" onclick=""></i>
+                        <i class="fa fa-arrow-down disabled" title="Down" onclick=""></i>
+                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
+                        <i class="fa fa-clone" title="Clone" onclick=""></i>
+                        <i class="fa fa-download" title="Download" onclick=""></i>
+                        <b>Albert</b> <i>Medium monstrosity (shapechanger), chaotic neutral</i>
+                    </li>
+            </div>
+            <h3>Preview</h3>
+            <p><b><i>Note:</i></b> This preview doesn't depict the scale or page layout of the actual print result. Use the
+                scale option of your browser's print dialog after pressing "Print".</p>
+            <p><b><i>Hint:</i></b> You can toggle the background graphics of the statblocks in your browser's print dialog.
+            </p>
+            <div id="print-options">
+                <input id="monochrome-print" type="checkbox" onchange="updatePrintOptions()">
+                <label for="monochrome-print">Monochrome statblocks</label>
+                <br>
+                <input id="save-paper" type="checkbox" onchange="updatePrintOptions()">
+                <label for="save-paper">Align two adjacent single-column statblocks next to each other</label>
+                <br>
+                <label for="print-margin">Margin between the statblocks: </label>
+                <input id="print-margin" type="number" onchange="updatePrintOptions()"> px
+                <br>
+                <button onclick="printBlocks()">Print</button>
+            </div>
+            <div id="print-preview">
+    
+            </div>
+        </div>
+        <div class="footer"><a href="https://github.com/Tetra-cube/Tetra-cube.github.io">GitHub Repo</a></div>
+    </div>
+    </div>
+</body>
+
+</html>

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -8,15 +8,14 @@
     <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="css/statblock-style.css">
     <link rel="stylesheet" type="text/css" href="css/statblock-page-style.css">
+    <link rel="stylesheet" type="text/css" href="css/statblock-print-style.css">
     <link rel="stylesheet" type="text/css" href="css/dnd-style.css">
     <link rel="stylesheet" type="text/css" href="css/libre-baskerville.css">
     <link rel="stylesheet" type="text/css" href="css/noto-sans.css">
-    <link rel="stylesheet" type="text/css" href="css/statblock-print-style.css">
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="css/all.min.css"> <!-- Font Awesome 5.9.0 -->
     <script src="js/jquery-3.4.1.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script src="js/FileSaver.min.js"></script>
-    <!-- <script src="js/dom-to-image.min.js"></script> -->
     <script src="js/statblock-script.js"></script>
     <script src="js/statblock-print-script.js"></script>
 </head>
@@ -34,32 +33,7 @@
                     <button onclick="$('#file-upload').click()">Load Statblock(s)</button>
                     <input id="file-upload" type="file" onChange="addStatblock()" hidden multiple/>
                 </h3>
-                <ul id="statblocks-list">
-                    <!-- Sample Data -->
-                    <!-- <li>
-                        <i class="fa fa-arrow-up disabled" title="Up" onclick=""></i>
-                        <i class="fa fa-arrow-down" title="Down" onclick=""></i>
-                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
-                        <i class="fa fa-clone" title="Clone" onclick=""></i>
-                        <i class="fa fa-download" title="Download" onclick=""></i>
-                        <b>Drakeling</b> <i>Small dragon, unaligned</i>
-                    </li>
-                    <li>
-                        <i class="fa fa-arrow-up" title="Up" onclick=""></i>
-                        <i class="fa fa-arrow-down" title="Down" onclick=""></i>
-                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
-                        <i class="fa fa-clone" title="Clone" onclick=""></i>
-                        <i class="fa fa-download" title="Download" onclick=""></i>
-                        <b>Fox</b> <i>Small beast, unaligned</i>
-                    </li>
-                    <li>
-                        <i class="fa fa-arrow-up" title="Up" onclick=""></i>
-                        <i class="fa fa-arrow-down disabled" title="Down" onclick=""></i>
-                        <i class="fa fa-trash-o" title="Remove" onclick=""></i>
-                        <i class="fa fa-clone" title="Clone" onclick=""></i>
-                        <i class="fa fa-download" title="Download" onclick=""></i>
-                        <b>Albert</b> <i>Medium monstrosity (shapechanger), chaotic neutral</i>
-                    </li> -->
+                <ul id="statblocks-list"></ul>
             </div>
             <h3>Preview</h3>
             <p><b><i>Note:</i></b> This preview doesn't depict the scale or page layout of the actual print result. Use the
@@ -70,11 +44,13 @@
                 <input id="monochrome-print-input" type="checkbox" onchange="updatePrintOptions()">
                 <label for="monochrome-print-input">Monochrome statblocks</label>
                 <br>
-                <input id="save-paper-input" type="checkbox" onchange="updatePrintOptions()">
+                <input id="save-paper-input" type="checkbox" checked onchange="refresh()">
                 <label for="save-paper-input">Align two adjacent single-column statblocks next to each other</label>
                 <br>
-                <label for="print-margin-input">Margin between the statblocks: </label>
-                <input id="print-margin-input" type="number" onchange="updatePrintOptions()"> px
+                <input id="print-margin-check-input" type="checkbox" checked onchange="refresh()">
+                <label for="print-margin-check-input">Margin between the statblocks: </label>
+                <input id="print-margin-input" type="text" value="0.2in" onchange="refresh()">
+                <span class="tooltip">?<span class="tooltiptext">All CSS units like "cm", "mm", "in", "pt", "px"... are supported.<br>See <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/length#absolute_length_units" target="_blank">mdn web docs <span class="fa fa-external-link-alt fa-sm"></span></a> for full reference.</span></span>
                 <br>
                 <button onclick="printBlocks()">Print</button>
             </div>

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -28,11 +28,16 @@
             <h1>Statblock printer</h1>
             <p>Print multiple statblocks on one sheet of paper.</p>
 
-            <div style="text-align: left; padding: 25px 0px;">
-                <h3>Included statblocks
-                    <button onclick="$('#file-upload').click()">Load Statblock(s)</button>
-                    <input id="file-upload" type="file" onChange="addStatblock()" hidden multiple/>
-                </h3>
+            <button onclick="$('#file-upload').click()">Load Statblock(s)...</button>
+            <input id="file-upload" type="file" onChange="addStatblock()" hidden multiple/>
+            <div id="monster-select-form">SRD/Tome of Beasts statblocks: 
+                <select id="monster-select">
+                    <option value="">-Select-</option>
+                </select> 
+                <button type="button" id="monster-select-button" onclick="loadPreset()">Add</button>
+            </div>
+            <div style="text-align: left; padding-bottom: 25px;">
+                <h3>Included statblocks:</h3>
                 <ul id="statblocks-list"></ul>
             </div>
             <h3>Preview</h3>

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -12,12 +12,13 @@
     <link rel="stylesheet" type="text/css" href="css/libre-baskerville.css">
     <link rel="stylesheet" type="text/css" href="css/noto-sans.css">
     <link rel="stylesheet" type="text/css" href="css/statblock-print-style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="js/jquery-3.4.1.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script src="js/FileSaver.min.js"></script>
-    <script src="js/dom-to-image.min.js"></script>
+    <!-- <script src="js/dom-to-image.min.js"></script> -->
     <script src="js/statblock-script.js"></script>
+    <script src="js/statblock-print-script.js"></script>
 </head>
 
 <body id="stat-block-body" style="min-width: 1000px;">
@@ -30,11 +31,12 @@
 
             <div style="text-align: left; padding: 25px 0px;">
                 <h3>Included statblocks
-                    <button onclick="addStatblock()">Load...</button>
+                    <button onclick="$('#file-upload').click()">Load Statblock(s)</button>
+                    <input id="file-upload" type="file" onChange="addStatblock()" hidden multiple/>
                 </h3>
                 <ul id="statblocks-list">
                     <!-- Sample Data -->
-                    <li>
+                    <!-- <li>
                         <i class="fa fa-arrow-up disabled" title="Up" onclick=""></i>
                         <i class="fa fa-arrow-down" title="Down" onclick=""></i>
                         <i class="fa fa-trash-o" title="Remove" onclick=""></i>
@@ -57,7 +59,7 @@
                         <i class="fa fa-clone" title="Clone" onclick=""></i>
                         <i class="fa fa-download" title="Download" onclick=""></i>
                         <b>Albert</b> <i>Medium monstrosity (shapechanger), chaotic neutral</i>
-                    </li>
+                    </li> -->
             </div>
             <h3>Preview</h3>
             <p><b><i>Note:</i></b> This preview doesn't depict the scale or page layout of the actual print result. Use the

--- a/dnd/dnd-statblock-print.html
+++ b/dnd/dnd-statblock-print.html
@@ -54,8 +54,10 @@
                 <br>
                 <button onclick="printBlocks()">Print</button>
             </div>
-            <div id="print-preview">
-    
+            <div id="print-preview-page">
+                <div id="print-preview">
+                    
+                </div>
             </div>
         </div>
         <div class="footer"><a href="https://github.com/Tetra-cube/Tetra-cube.github.io">GitHub Repo</a></div>

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -63,6 +63,7 @@
                 <input id="print-color-mode" type="checkbox">
                 <label for="print-color-mode" title="Print the statblock shown below if checked, or a black-and-white version if not.">Color mode</label>
             </span>
+            <button onclick="PrintMultiple()">Print Multiple...</button>
             <button onclick="TryImage()">View Image</button>
             <button onclick="TryMarkdown()">View Markdown</button>
             <input id="file-upload" type="file" onChange="TryLoadFile();" hidden />

--- a/dnd/dnd-statblock.html
+++ b/dnd/dnd-statblock.html
@@ -57,7 +57,12 @@
             <br>
             <button onclick="TrySaveFile()">Save Statblock</button>
             <button onclick="LoadFilePrompt()">Load Statblock</button>
-            <button onclick="TryPrint()">Printable Block</button>
+            <span style="display: inline-table;">
+                <button onclick="TryPrint()">Printable Block</button>
+                <br>
+                <input id="print-color-mode" type="checkbox">
+                <label for="print-color-mode" title="Print the statblock shown below if checked, or a black-and-white version if not.">Color mode</label>
+            </span>
             <button onclick="TryImage()">View Image</button>
             <button onclick="TryMarkdown()">View Markdown</button>
             <input id="file-upload" type="file" onChange="TryLoadFile();" hidden />

--- a/dnd/js/statblock-print-script.js
+++ b/dnd/js/statblock-print-script.js
@@ -240,4 +240,27 @@ $(() => {
         data = json
         refresh();
     });
+
+    // initialise drag&drop
+    let b = $("body")[0];
+    let overlay = $("#dragndrop-overlay");
+    /* b.ondragover = b.ondragenter = evt => {
+        evt.preventDefault();
+    }; */
+    b.ondragover = evt => {
+        evt.preventDefault();
+    }
+    b.ondragenter = evt => {
+        evt.preventDefault();
+        overlay.removeClass("hidden");
+    }
+    overlay[0].ondragleave = evt => {
+        overlay.addClass("hidden");
+    }
+    b.ondrop = evt => {
+        evt.preventDefault();
+        $('#file-upload')[0].files = evt.dataTransfer.files;
+        overlay.addClass("hidden");
+        addStatblock();
+    }
 })

--- a/dnd/js/statblock-print-script.js
+++ b/dnd/js/statblock-print-script.js
@@ -1,6 +1,7 @@
+// var data;
 let statblocks = [];
 
-const BLOCKTEMPLATE = `<div id="stat-block-wrapper">
+const BLOCKTEMPLATE = `<div> <!-- id="stat-block-wrapper" class="content" -->
 <div id="stat-block" class="stat-block">
     <hr class="orange-border" />
     <div class="section-left">
@@ -87,8 +88,6 @@ let blockList = {
     },
     down: (elem) => {
         let i = elem.index();
-        console.log(elem);
-        console.log(i);
         [statblocks[i+1], statblocks[i]] = [statblocks[i], statblocks[i+1]];
         refresh();
     },
@@ -120,12 +119,25 @@ function addStatblock() { // read every selected file and push it to the statblo
     });
 }
 
-function refresh() {
-    // Refresh statblock list
-    $("#statblocks-list").empty();
+function updatePrintOptions() {
+    // monochrome print
+    if($("#monochrome-print-input").prop("checked")) {
+        $("#print-preview > div").attr("id", "print-block")
+    } else {
+        $("#print-preview > div").removeAttr("id")
+    }
+}
 
+
+function refresh() {
+    let statblocksList = $("#statblocks-list");
+    let printPreview = $("#print-preview");
+    statblocksList.empty();
+    printPreview.empty();
+    
     $.each(statblocks, (index, mon) => {
-        $("#statblocks-list").append(
+        // Refresh statblock list
+        statblocksList.append(
             `<li>
                 <i class="fa fa-arrow-up ${index == 0 ? 'disabled' : ''}" title="Up" onclick="${index>0 ? 'blockList.up($(this).parent())' : ''}"></i>
                 <i class="fa fa-arrow-down ${index + 1 == statblocks.length ? 'disabled' : ''}" title="Down" onclick="${index + 1 == statblocks.length ? '' : 'blockList.down($(this).parent())'}"></i>
@@ -134,9 +146,21 @@ function refresh() {
                 <i class="fa fa-download" title="Download" onclick="blockList.download($(this).parent())"></i>
                 <b>${StringFunctions.RemoveHtmlTags(mon.name)}</b> <i>${StringFunctions.StringCapitalize(StringFunctions.RemoveHtmlTags(mon.size) + " " + mon.type + (mon.tag == "" ? ", " : " (" + mon.tag + "), ") + mon.alignment)}</i>
             </li>`
-        )
+        );
+
+        // Refresh print preview
+        printPreview.append(BLOCKTEMPLATE);
+        var currentStatblock = $("#print-preview > div:last-child");
+        UpdateStatblock(undefined, mon);
+        // delete all IDs so this statblock will be preserved
+        currentStatblock.removeAttr("id");
+        /* var inner = currentStatblock.html();
+        inner = inner.replaceAll(/id=".*?"/g, '');
+        currentStatblock.html(inner); */
+
+        currentStatblock.html(currentStatblock.html().replaceAll(/id=".*?"/g, ''));
+
     })
-    // Refresh print preview
     // UpdateStatblock()
 }
 
@@ -146,5 +170,8 @@ $(() => {
     let savedData = localStorage.getItem("SavedData");
     if (savedData != undefined)
         statblocks.push(JSON.parse(savedData));
-    refresh();
+    $.getJSON("js/JSON/statblockdata.json", json => {
+        data = json
+        refresh();
+    });
 })

--- a/dnd/js/statblock-print-script.js
+++ b/dnd/js/statblock-print-script.js
@@ -1,0 +1,150 @@
+let statblocks = [];
+
+const BLOCKTEMPLATE = `<div id="stat-block-wrapper">
+<div id="stat-block" class="stat-block">
+    <hr class="orange-border" />
+    <div class="section-left">
+        <div class="creature-heading">
+            <h1 id="monster-name">Monster</h1>
+            <h2 id="monster-type">Size, type, alignment</h2>
+        </div> <!-- creature heading -->
+        <svg height="5" width="100%" class="tapered-rule">
+            <polyline points="0,0 400,2.5 0,5"></polyline>
+        </svg>
+        <div class="top-stats">
+            <div class="property-line first">
+                <h4>Armor Class</h4>
+                <p id="armor-class"></p>
+            </div> <!-- property line -->
+            <div class="property-line">
+                <h4>Hit Points</h4>
+                <p id="hit-points"></p>
+            </div> <!-- property line -->
+            <div class="property-line last">
+                <h4>Speed</h4>
+                <p id="speed"></p>
+            </div> <!-- property line -->
+            <svg height="5" width="100%" class="tapered-rule">
+                <polyline points="0,0 400,2.5 0,5"></polyline>
+            </svg>
+            <div class="scores">
+                <div class="scores-strength">
+                    <h4>STR</h4>
+                    <p id="strpts"></p>
+                </div> <!-- scores strength -->
+                <div class="scores-dexterity">
+                    <h4>DEX</h4>
+                    <p id="dexpts"></p>
+                </div> <!-- scores dexterity -->
+                <div class="scores-constitution">
+                    <h4>CON</h4>
+                    <p id="conpts"></p>
+                </div> <!-- scores constitution -->
+                <div class="scores-intelligence">
+                    <h4>INT</h4>
+                    <p id="intpts"></p>
+                </div> <!-- scores intelligence -->
+                <div class="scores-wisdom">
+                    <h4>WIS</h4>
+                    <p id="wispts"></p>
+                </div> <!-- scores wisdom -->
+                <div class="scores-charisma">
+                    <h4>CHA</h4>
+                    <p id="chapts"></p>
+                </div> <!-- scores charisma -->
+            </div> <!-- scores -->
+            <svg height="5" width="100%" class="tapered-rule">
+                <polyline points="0,0 400,2.5 0,5"></polyline>
+            </svg>
+            <div id="properties-list"></div>
+            <div id="challenge-rating-line" class="property-line last">
+                <h4>Challenge</h4>
+                <p id="challenge-rating"></p>
+            </div> <!-- property line -->
+        </div> <!-- top stats -->
+        <svg height="5" width="100%" class="tapered-rule">
+            <polyline points="0,0 400,2.5 0,5"></polyline>
+        </svg>
+        <div class="actions">
+            <div id="traits-list-left"></div>
+        </div> <!-- actions -->
+    </div> <!-- section left -->
+    <div class="section-right">
+        <div class="actions">
+            <div id="traits-list-right"></div>
+        </div> <!-- actions -->
+    </div> <!-- section right -->
+    <hr class="orange-border bottom" />
+</div>
+</div> <!-- stat block -->`
+
+// Methods for the statblock list entries's buttons
+let blockList = {
+    up: (elem) => {
+        let i = elem.index();
+        [statblocks[i-1], statblocks[i]] = [statblocks[i], statblocks[i-1]];
+        refresh();
+    },
+    down: (elem) => {
+        let i = elem.index();
+        console.log(elem);
+        console.log(i);
+        [statblocks[i+1], statblocks[i]] = [statblocks[i], statblocks[i+1]];
+        refresh();
+    },
+    remove: (elem) => {
+        statblocks.splice(elem.index(), 1);
+        refresh();
+    },
+    clone: (elem) => {
+        i = elem.index();
+        statblocks.splice(i, 0, statblocks[i])
+        refresh();
+    },
+    download: (elem) => {
+        let mon = statblocks[elem.index()];
+        saveAs(new Blob([JSON.stringify(mon)], {
+            type: "text/plain;charset=utf-8"
+        }), mon.name.toLowerCase() + ".monster")
+    }
+}
+
+function addStatblock() { // read every selected file and push it to the statblocks list
+    Array.from($("#file-upload").prop("files")).forEach(file => {
+        let reader = new FileReader();
+        reader.onload = function (e) {
+            statblocks.push(JSON.parse(reader.result));
+            refresh()
+        };
+        reader.readAsText(file);
+    });
+}
+
+function refresh() {
+    // Refresh statblock list
+    $("#statblocks-list").empty();
+
+    $.each(statblocks, (index, mon) => {
+        $("#statblocks-list").append(
+            `<li>
+                <i class="fa fa-arrow-up ${index == 0 ? 'disabled' : ''}" title="Up" onclick="${index>0 ? 'blockList.up($(this).parent())' : ''}"></i>
+                <i class="fa fa-arrow-down ${index + 1 == statblocks.length ? 'disabled' : ''}" title="Down" onclick="${index + 1 == statblocks.length ? '' : 'blockList.down($(this).parent())'}"></i>
+                <i class="fa fa-trash-o" title="Remove" onclick="blockList.remove($(this).parent())"></i>
+                <i class="fa fa-clone" title="Clone" onclick="blockList.clone($(this).parent())"></i>
+                <i class="fa fa-download" title="Download" onclick="blockList.download($(this).parent())"></i>
+                <b>${StringFunctions.RemoveHtmlTags(mon.name)}</b> <i>${StringFunctions.StringCapitalize(StringFunctions.RemoveHtmlTags(mon.size) + " " + mon.type + (mon.tag == "" ? ", " : " (" + mon.tag + "), ") + mon.alignment)}</i>
+            </li>`
+        )
+    })
+    // Refresh print preview
+    // UpdateStatblock()
+}
+
+// Document ready function
+$(() => {
+    // Load statblock from cache
+    let savedData = localStorage.getItem("SavedData");
+    if (savedData != undefined)
+        statblocks.push(JSON.parse(savedData));
+    refresh();
+})

--- a/dnd/js/statblock-print-script.js
+++ b/dnd/js/statblock-print-script.js
@@ -120,6 +120,19 @@ function addStatblock() { // read every selected file and push it to the statblo
     });
 }
 
+function loadPreset() {
+    let name = $("#monster-select").val();
+    if (name == "") return;
+    $.getJSON("https://api.open5e.com/monsters/" + name + "/", (jsonArr) => {
+        statblocks.push(structuredClone(GetVariablesFunctions.SetPreset(jsonArr)));
+        refresh()
+    })
+        .fail(function () {
+            console.error("Failed to load preset.");
+            return;
+        })
+}
+
 function printBlocks() {
     let printWindow = window.open();
     printWindow.document.write(`<html>
@@ -171,57 +184,49 @@ function refresh() {
         );
 
         // Refresh print preview
-        // var insertStatblockInto;
         var style;
 
         if(isAlreadyHori) {
             // End of side-by-side (this statblock: right)
-            // insertStatblockInto = $("#print-preview > div.side-by-side:last-child");
             isAlreadyHori = false;
             style = "margin-bottom: " + printMargin;
             if(index != statblocks.length-1) style += "; float: right";
         } else if(savePaper && !mon.doubleColumns && index != statblocks.length-1 && !statblocks[index+1].doubleColumns) {
             // Start of side-by-side (this statblock: left)
             // printPreview.append('<div class="side-by-side"></div>')
-            // insertStatblockInto = $("#print-preview > div.side-by-side:last-child").css("width", "calc(800px + " + printMargin + ")");
             isAlreadyHori = true;
             savePaperApplied = true;
             style = `float: inline-start; margin: 0px ${printMargin} ${printMargin} 0px`;
         } else {
             // normal
-            // insertStatblockInto = printPreview;
             style = `margin: 0px ${printMargin} ${printMargin} 0px`;
         }
 
         printPreview.append(BLOCKTEMPLATE);
         var currentStatblockContainer = printPreview.children().last();
-        UpdateStatblock(undefined, mon);
-        // if(isAlreadyHori) currentStatblockContainer.css("float", "left"); // first block (left)
+        UpdateStatblock(undefined, structuredClone(mon));
 
         // delete all IDs so this statblock won't be affected by later calls of UpdateStatblock()
         currentStatblockContainer.removeAttr("id");
         currentStatblockContainer.html(currentStatblockContainer.html().replaceAll(/id=".*?"/g, ''));
 
         // add CSS
-        console.log(index, style);
         currentStatblockContainer[0].style = style;
-        // monochrome print
-        if($("#monochrome-print-input").prop("checked")) {
-            $(".stat-block-container").attr("id", "print-block")
-        } else {
-            $(".stat-block-container").removeAttr("id")
-        }
-
-        // margins
-        // $(".stat-block-container:not(:last-child)").css("margin", "0px " + printMargin + " " + printMargin + " 0px"); // right and bottom
-        // $(".side-by-side > :last-child").css("margin-bottom", printMargin);
     });
-
+    
     // determine width of #print-preview
     let width = "400px" // one-column statblocks, vertically aligned
     if($("#print-preview .stat-block.wide").length) width = "800px" // at least one two-column statblock exists
     if(savePaperApplied) width = `calc(800px + ${printMargin})`
+
     $("#print-preview").css("width", width)
+
+    // monochrome print
+    if($("#monochrome-print-input").prop("checked")) {
+        $(".stat-block-container").attr("id", "print-block")
+    } else {
+        $(".stat-block-container").removeAttr("id")
+    }
 }
 
 // Document ready function

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -99,6 +99,12 @@ function TryPrint() {
     printWindow.document.write('</div></body></html>');
 }
 
+// Print multiple function
+
+function PrintMultiple() {
+    window.location = "dnd-statblock-print.html";
+}
+
 // View as image function
 function TryImage() {
     domtoimage.toBlob(document.getElementById("stat-block"))
@@ -1974,6 +1980,7 @@ var ArrayFunctions = {
 
 // Document ready function
 $(function () {
+    if(window.location.toString().slice(-19) != "/dnd-statblock.html") return; // This script is also used by other pages -> execute this function only for the statblock generator page
     // Load the preset monster names
     $.getJSON("https://api.open5e.com/monsters/?format=json&fields=slug,name&limit=1000&document__slug=wotc-srd", function (srdArr) {
         let monsterSelect = $("#monster-select");

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -174,8 +174,8 @@ function UpdateStatblock(moveSeparationPoint, monOverride) {
     if (moveSeparationPoint != undefined)
         mon.separationPoint = MathFunctions.Clamp(mon.separationPoint + moveSeparationPoint, 0, separationMax);
 
-    // Save Before Continuing
-    SavedData.SaveToLocalStorage();
+    // Save Before Continuing - generator only
+    if(monOverride == undefined) SavedData.SaveToLocalStorage();
 
     // One column or two columns
     let statBlock = $("#stat-block");

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -92,8 +92,9 @@ var TryLoadFile = () => {
 
 // Print function
 function TryPrint() {
+    let colorMode = $("#print-color-mode").is(":checked");
     let printWindow = window.open();
-    printWindow.document.write('<html><head><meta charset="utf-8"/><title>' + mon.name + '</title><link rel="shortcut icon" type="image/x-icon" href="./dndimages/favicon.ico" /><link rel="stylesheet" type="text/css" href="css/statblock-style.css"><link rel="stylesheet" type="text/css" href="css/libre-baskerville.css"><link rel="stylesheet" type="text/css" href="css/noto-sans.css"></head><body><div id="print-block" class="content">');
+    printWindow.document.write('<html><head><meta charset="utf-8"/><title>' + mon.name + '</title><link rel="shortcut icon" type="image/x-icon" href="./dndimages/favicon.ico" /><link rel="stylesheet" type="text/css" href="css/statblock-style.css"><link rel="stylesheet" type="text/css" href="css/libre-baskerville.css"><link rel="stylesheet" type="text/css" href="css/noto-sans.css"></head><body><div id="' + (colorMode?'stat-block-wrapper':'print-block') + '" class="content">');
     printWindow.document.write($("#stat-block-wrapper").html());
     printWindow.document.write('</div></body></html>');
 }

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -151,7 +151,8 @@ var SavedData = {
 }
 
 // Update the main stat block
-function UpdateStatblock(moveSeparationPoint) {
+function UpdateStatblock(moveSeparationPoint, monOverride) {
+    if(monOverride != undefined) mon = monOverride; // used by the printer; within the generator, monOverride is always undefined
     // Set Separation Point
     let separationMax = mon.abilities.length + mon.actions.length + mon.bonusActions.length + mon.reactions.length - 1;
 

--- a/dnd/js/statblock-script.js
+++ b/dnd/js/statblock-script.js
@@ -1440,6 +1440,7 @@ var GetVariablesFunctions = {
             AbilityPresetLoop(regionalsPresetArr, "regionals");
 
         mon.separationPoint = undefined; // This will make the separation point be automatically calculated in UpdateStatblock
+        return mon; // for statblock-print
     },
 
     // Add stuff to arrays
@@ -1981,7 +1982,6 @@ var ArrayFunctions = {
 
 // Document ready function
 $(function () {
-    if(window.location.toString().slice(-19) != "/dnd-statblock.html") return; // This script is also used by other pages -> execute this function only for the statblock generator page
     // Load the preset monster names
     $.getJSON("https://api.open5e.com/monsters/?format=json&fields=slug,name&limit=1000&document__slug=wotc-srd", function (srdArr) {
         let monsterSelect = $("#monster-select");
@@ -2004,7 +2004,8 @@ $(function () {
         .fail(function () {
             $("#monster-select-form").html("Unable to load monster presets.")
         });
-
+        
+    if(window.location.toString().slice(-25) == "/dnd-statblock-print.html") return; // This script is also used by other pages -> execute the following only for the statblock generator page
     // Load the json data
     $.getJSON("js/JSON/statblockdata.json", function (json) {
         data = json;


### PR DESCRIPTION
Adds a new page where you can load several statblocks (the one cached is loaded by default), arrange and print them.

I've reused the statblock rendering code from statblock-script.js but not refactored it into an external script, so the way this is implemented is quite... lazy, but it works.

Pull request #34 is already included.

See also #11 